### PR TITLE
Refactor `llm_*` Function Call Structure for Enhanced Flexibility in Prompt Specification

### DIFF
--- a/src/core/functions/aggregate/llm_first.cpp
+++ b/src/core/functions/aggregate/llm_first.cpp
@@ -9,7 +9,7 @@ namespace core {
 
 void CoreAggregateFunctions::RegisterLlmFirstFunction(DatabaseInstance &db) {
     auto string_concat =
-        AggregateFunction("llm_first", {LogicalType::VARCHAR, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
+        AggregateFunction("llm_first", {LogicalType::ANY, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
                           AggregateFunction::StateSize<LlmAggState>, LlmAggOperation::Initialize,
                           LlmAggOperation::Operation, LlmAggOperation::Combine,
                           LlmAggOperation::FirstOrLastFinalize<FirstOrLast::FIRST>, LlmAggOperation::SimpleUpdate);

--- a/src/core/functions/aggregate/llm_last.cpp
+++ b/src/core/functions/aggregate/llm_last.cpp
@@ -9,7 +9,7 @@ namespace core {
 
 void CoreAggregateFunctions::RegisterLlmLastFunction(DatabaseInstance &db) {
     auto string_concat =
-        AggregateFunction("llm_last", {LogicalType::VARCHAR, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
+        AggregateFunction("llm_last", {LogicalType::ANY, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
                           AggregateFunction::StateSize<LlmAggState>, LlmAggOperation::Initialize,
                           LlmAggOperation::Operation, LlmAggOperation::Combine,
                           LlmAggOperation::FirstOrLastFinalize<FirstOrLast::LAST>, LlmAggOperation::SimpleUpdate);

--- a/src/core/functions/aggregate/llm_rerank.cpp
+++ b/src/core/functions/aggregate/llm_rerank.cpp
@@ -123,7 +123,7 @@ void LlmAggOperation::RerankerFinalize(Vector &states, AggregateInputData &aggr_
 
 void CoreAggregateFunctions::RegisterLlmRerankFunction(DatabaseInstance &db) {
     auto string_concat = AggregateFunction(
-        "llm_rerank", {LogicalType::VARCHAR, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
+        "llm_rerank", {LogicalType::ANY, LogicalType::ANY, LogicalType::ANY}, LogicalType::JSON(),
         AggregateFunction::StateSize<LlmAggState>, LlmAggOperation::Initialize, LlmAggOperation::Operation,
         LlmAggOperation::Combine, LlmAggOperation::RerankerFinalize, LlmAggOperation::SimpleUpdate);
 

--- a/src/core/functions/batch_response_builder.cpp
+++ b/src/core/functions/batch_response_builder.cpp
@@ -20,40 +20,27 @@ std::vector<nlohmann::json> CastVectorOfStructsToJson(Vector &struct_vector, int
     return vector_json;
 }
 
-struct PromptDetails {
-    std::string prompt_name;
-    std::string prompt;
-
-    std::string GetPrompt() {
-        if (prompt_name.empty()) {
-            return prompt;
-        }
-
-        auto query_result = CoreModule::GetConnection().Query(
-            "SELECT prompt FROM flockmtl_config.FLOCKMTL_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" + prompt_name +
-            "'");
-        if (query_result->RowCount() == 0) {
-            throw std::runtime_error("The provided `" + prompt_name + "` prompt not found");
-        }
-        prompt = query_result->GetValue(0, 0).ToString();
-        return prompt;
-    }
-};
-
-PromptDetails CreatePormptDetails(Connection &con, const nlohmann::json prompt_details_json) {
+PromptDetails CreatePromptDetails(Connection &con, const nlohmann::json prompt_details_json) {
     PromptDetails prompt_details;
     if (prompt_details_json.size() != 1) {
         throw std::runtime_error(
-            "The prompt_details_json should contain a single key value pair of prompt_name or prompt");
+            "The prompt details struct should contain a single key value pair of prompt_name or prompt");
     }
 
     if (prompt_details_json.contains("prompt_name")) {
         prompt_details.prompt_name = prompt_details_json["prompt_name"];
+        auto query_result =
+            con.Query("SELECT prompt FROM flockmtl_config.FLOCKMTL_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" +
+                      prompt_details.prompt_name + "'");
+        if (query_result->RowCount() == 0) {
+            throw std::runtime_error("The provided `" + prompt_details.prompt_name + "` prompt not found");
+        }
+        prompt_details.prompt = query_result->GetValue(0, 0).ToString();
     } else if (prompt_details_json.contains("prompt")) {
         prompt_details.prompt = prompt_details_json["prompt"];
     } else {
         throw std::runtime_error(
-            "The prompt_details_json should contain a single key value pair of prompt_name or prompt");
+            "The prompt details struct should contain a single key value pair of prompt_name or prompt");
     }
     return prompt_details;
 }
@@ -71,16 +58,8 @@ nlohmann::json Complete(const nlohmann::json &tuples, const std::string &user_pr
     return response["tuples"];
 };
 
-nlohmann::json BatchAndComplete(std::vector<nlohmann::json> &tuples, Connection &con, std::string user_prompt_name,
+nlohmann::json BatchAndComplete(std::vector<nlohmann::json> &tuples, Connection &con, std::string user_prompt,
                                 const std::string &llm_template, const ModelDetails &model_details) {
-
-    auto query_result =
-        con.Query("SELECT prompt FROM flockmtl_config.FLOCKMTL_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" +
-                  user_prompt_name + "'");
-    if (query_result->RowCount() == 0) {
-        throw std::runtime_error("Prompt not found");
-    }
-    auto user_prompt = query_result->GetValue(0, 0).ToString();
 
     int num_tokens_meta_and_user_pormpt = 0;
     num_tokens_meta_and_user_pormpt += Tiktoken::GetNumTokens(user_prompt);

--- a/src/core/functions/scalar/llm_complete_json.cpp
+++ b/src/core/functions/scalar/llm_complete_json.cpp
@@ -22,27 +22,21 @@ static void LlmCompleteJsonScalarFunction(DataChunk &args, ExpressionState &stat
     Connection con(*state.GetContext().db);
     CoreScalarParsers::LlmCompleteJsonScalarParser(args);
 
-    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[1], 1)[0];
+    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[0], 1)[0];
     auto model_details = ModelManager::CreateModelDetails(con, model_details_json);
+    auto prompt_details_json = CoreScalarParsers::Struct2Json(args.data[1], 1)[0];
+    auto prompt_details = CreatePromptDetails(con, prompt_details_json);
 
     if (args.ColumnCount() == 2) {
-        auto query_result =
-            con.Query("SELECT prompt FROM flockmtl_config.FLOCKMTL_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" +
-                      args.data[0].GetValue(0).ToString() + "'");
-
-        if (query_result->RowCount() == 0) {
-            throw std::runtime_error("Prompt not found");
-        }
-
-        auto template_str = query_result->GetValue(0, 0).ToString() + "\nThe Ouput should be in JSON format.";
+        auto template_str = prompt_details.prompt + "\nThe Ouput should be in JSON format.";
         auto response = ModelManager::CallComplete(template_str, model_details);
 
         result.SetValue(0, response.dump());
     } else {
         auto tuples = CoreScalarParsers::Struct2Json(args.data[2], args.size());
 
-        auto responses = BatchAndComplete(tuples, con, args.data[0].GetValue(0).ToString(),
-                                          llm_complete_json_prompt_template, model_details);
+        auto responses =
+            BatchAndComplete(tuples, con, prompt_details.prompt, llm_complete_json_prompt_template, model_details);
 
         auto index = 0;
         for (const auto &response : responses) {

--- a/src/core/functions/scalar/llm_embedding.cpp
+++ b/src/core/functions/scalar/llm_embedding.cpp
@@ -14,8 +14,8 @@ static void LlmEmbeddingScalarFunction(DataChunk &args, ExpressionState &state, 
     Connection con(*state.GetContext().db);
     CoreScalarParsers::LlmEmbeddingScalarParser(args);
 
-    auto inputs = CoreScalarParsers::Struct2Json(args.data[0], args.size());
-    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[1], 1)[0];
+    auto inputs = CoreScalarParsers::Struct2Json(args.data[1], args.size());
+    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[0], 1)[0];
     auto model_details = ModelManager::CreateModelDetails(con, model_details_json);
 
     vector<string> prepared_inputs;

--- a/src/core/functions/scalar/llm_filter.cpp
+++ b/src/core/functions/scalar/llm_filter.cpp
@@ -21,13 +21,14 @@ static void LlmFilterScalarFunction(DataChunk &args, ExpressionState &state, Vec
     Connection con(*state.GetContext().db);
     CoreScalarParsers::LlmFilterScalarParser(args);
 
-    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[1], 1)[0];
+    auto model_details_json = CoreScalarParsers::Struct2Json(args.data[0], 1)[0];
     auto model_details = ModelManager::CreateModelDetails(con, model_details_json);
+    auto prompt_details_json = CoreScalarParsers::Struct2Json(args.data[1], 1)[0];
+    auto prompt_details = CreatePromptDetails(con, prompt_details_json);
 
     auto tuples = CoreScalarParsers::Struct2Json(args.data[2], args.size());
 
-    auto responses =
-        BatchAndComplete(tuples, con, args.data[0].GetValue(0).ToString(), llm_filter_prompt_template, model_details);
+    auto responses = BatchAndComplete(tuples, con, prompt_details.prompt, llm_filter_prompt_template, model_details);
 
     auto index = 0;
     Vector vec(LogicalType::VARCHAR, args.size());

--- a/src/core/parser/scalar/llm_complete.cpp
+++ b/src/core/parser/scalar/llm_complete.cpp
@@ -11,14 +11,13 @@ void CoreScalarParsers::LlmCompleteScalarParser(DataChunk &args) {
         throw std::runtime_error("LlmCompleteScalarParser: Invalid number of arguments.");
     }
 
-    // check if template is a string
-    if (args.data[0].GetType() != LogicalType::VARCHAR) {
-        throw std::runtime_error("LlmCompleteScalarParser: Template must be a string.");
+    if (args.data[0].GetType().id() != LogicalTypeId::STRUCT) {
+        throw std::runtime_error("LlmCompleteScalarParser: Model details must be a string.");
     }
-    // check if model details is a struct
     if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
-        throw std::runtime_error("LlmCompleteScalarParser: Model details must be a struct.");
+        throw std::runtime_error("LlmCompleteScalarParser: Prompt details must be a struct.");
     }
+
     if (args.ColumnCount() == 3) {
         if (args.data[2].GetType().id() != LogicalTypeId::STRUCT) {
             throw std::runtime_error("LlmCompleteScalarParser: Inputs must be a struct.");

--- a/src/core/parser/scalar/llm_complete_json.cpp
+++ b/src/core/parser/scalar/llm_complete_json.cpp
@@ -25,13 +25,11 @@ void CoreScalarParsers::LlmCompleteJsonScalarParser(DataChunk &args) {
         throw std::runtime_error("LlmCompleteJsonScalarParser: Invalid number of arguments.");
     }
 
-    // check if template is a string
-    if (args.data[0].GetType() != LogicalType::VARCHAR) {
-        throw std::runtime_error("LlmCompleteJsonScalarParser: Template must be a string.");
-    }
-    // check if model details is a struct
-    if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
+    if (args.data[0].GetType().id() != LogicalTypeId::STRUCT) {
         throw std::runtime_error("LlmCompleteJsonScalarParser: Model details must be a struct.");
+    }
+    if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
+        throw std::runtime_error("LlmCompleteJsonScalarParser: Prompt details must be a struct.");
     }
 
     if (args.ColumnCount() == 3) {

--- a/src/core/parser/scalar/llm_embedding.cpp
+++ b/src/core/parser/scalar/llm_embedding.cpp
@@ -11,11 +11,10 @@ void CoreScalarParsers::LlmEmbeddingScalarParser(DataChunk &args) {
         throw std::runtime_error("LlmEmbedScalarParser: Invalid number of arguments.");
     }
     if (args.data[0].GetType().id() != LogicalTypeId::STRUCT) {
-        throw std::runtime_error("LlmEmbedScalarParser: Inputs must be a struct.");
-    }
-    // check if model details is a struct
-    if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
         throw std::runtime_error("LlmEmbedScalarParser: Model details must be a struct.");
+    }
+    if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
+        throw std::runtime_error("LlmEmbedScalarParser: Inputs must be a struct.");
     }
 }
 

--- a/src/core/parser/scalar/llm_filter.cpp
+++ b/src/core/parser/scalar/llm_filter.cpp
@@ -8,20 +8,17 @@ namespace core {
 
 void CoreScalarParsers::LlmFilterScalarParser(DataChunk &args) {
     if (args.ColumnCount() != 3) {
-        throw std::runtime_error("LlmCompleteScalarParser: Invalid number of arguments.");
+        throw std::runtime_error("LlmFilterScalarParser: Invalid number of arguments.");
     }
 
-    // check if template is a string
-    if (args.data[0].GetType() != LogicalType::VARCHAR) {
-        throw std::runtime_error("LlmCompleteScalarParser: Template must be a string.");
+    if (args.data[0].GetType().id() != LogicalTypeId::STRUCT) {
+        throw std::runtime_error("LlmFilterScalarParser: Model details must be a struct.");
     }
-    // check if model details is a struct
     if (args.data[1].GetType().id() != LogicalTypeId::STRUCT) {
-        throw std::runtime_error("LlmCompleteScalarParser: Model details must be a struct.");
+        throw std::runtime_error("LlmFilterScalarParser: Prompt details must be a struct.");
     }
-
     if (args.data[2].GetType().id() != LogicalTypeId::STRUCT) {
-        throw std::runtime_error("LlmCompleteScalarParser: Inputs must be a struct.");
+        throw std::runtime_error("LlmFilterScalarParser: Inputs must be a struct.");
     }
 }
 

--- a/src/include/flockmtl/core/functions/batch_response_builder.hpp
+++ b/src/include/flockmtl/core/functions/batch_response_builder.hpp
@@ -8,6 +8,13 @@ namespace core {
 
 std::vector<nlohmann::json> CastVectorOfStructsToJson(Vector &struct_vector, int size);
 
+struct PromptDetails {
+    std::string prompt_name;
+    std::string prompt;
+};
+
+PromptDetails CreatePromptDetails(Connection &con, const nlohmann::json prompt_details_json);
+
 nlohmann::json Complete(const nlohmann::json &tuples, const std::string &user_prompt, const std::string &llm_template,
                         const ModelDetails &model_details);
 


### PR DESCRIPTION
This change updates the `llm_*` function call format to allow a more flexible and abstracted specification of prompts and prompt names. The previous structure, which required `llm_filter('validate-email', {'model_name': 'default'}, {'email': email})`, is now updated to accept parameters in the following format:

1. **Prompt-Based Calls:** `llm_filter({'model_name': 'default'}, {'prompt': 'return the invalid emails'}, {'email': email})`
2. **Named Prompt Calls:** `llm_filter({'model_name': 'default'}, {'prompt-name': 'validate-email'}, {'email': email})`

This refactor allows for easier adaptation to various prompt names and specifications, enhancing modularity and reusability across different use cases.