### PR TITLE
Add `fusion_relative` Function for Score Normalization and Max Aggregation

### DIFF
--- a/src/core/functions/scalar/CMakeLists.txt
+++ b/src/core/functions/scalar/CMakeLists.txt
@@ -4,4 +4,5 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_complete.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_embedding.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_filter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fusion_relative.cpp
     PARENT_SCOPE)

--- a/src/core/functions/scalar/fusion_relative.cpp
+++ b/src/core/functions/scalar/fusion_relative.cpp
@@ -16,11 +16,15 @@ static void FusionRelativeScalarFunction(DataChunk &args, ExpressionState &state
     for (auto i = 0; i < args.size(); i++) {
         auto max = 0.0;
         for (auto j = 0; j < args.ColumnCount(); j++) {
-            auto value = args.data[j].GetValue(i).GetValue<double>();
-            if (value > max) {
-                max = value;
+            auto valueWrapper = args.data[j].GetValue(i);
+            if (!valueWrapper.IsNull()) {
+                auto value = valueWrapper.GetValue<double>();
+                if (value > max) {
+                    max = value;
+                }
             }
         }
+
         result.SetValue(i, max);
     }
 }

--- a/src/core/functions/scalar/fusion_relative.cpp
+++ b/src/core/functions/scalar/fusion_relative.cpp
@@ -10,61 +10,18 @@
 namespace flockmtl {
 namespace core {
 
-std::vector<double> normalize(const std::vector<double> &scores) {
-
-    double min_val = *std::min_element(scores.begin(), scores.end());
-    double max_val = *std::max_element(scores.begin(), scores.end());
-
-    std::vector<double> normalized;
-    if (max_val == min_val) {
-        normalized.resize(scores.size(), 0.0);
-    } else {
-        for (double score : scores) {
-            normalized.push_back((score - min_val) / (max_val - min_val));
-        }
-    }
-
-    return normalized;
-}
-
-std::vector<int> fusion_relative(DataChunk &args) {
-    size_t column_size = args.ColumnCount();
-    size_t tuple_size = args.size();
-
-    std::vector<std::vector<double>> normalized_columns;
-    for (size_t i = 0; i < column_size; i++) {
-        std::vector<double> scores;
-        for (size_t j = 0; j < tuple_size; j++) {
-            scores.push_back(args.data[i].GetValue(j).GetValue<double>());
-        }
-        std::vector<double> normalized_scores = normalize(scores);
-        normalized_columns.push_back(normalized_scores);
-    }
-
-    std::vector<int> result_idx;
-    for (size_t i = 0; i < tuple_size; i++) {
-        double max_score = 0.0;
-        int max_idx = 0;
-        for (size_t j = 0; j < column_size; j++) {
-            if (normalized_columns[j][i] > max_score) {
-                max_score = normalized_columns[j][i];
-                max_idx = j;
-            }
-        }
-        result_idx.push_back(max_idx);
-    }
-
-    return result_idx;
-}
-
 static void FusionRelativeScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     CoreScalarParsers::FusionRelativeScalarParser(args);
 
-    std::vector<std::vector<double>> score_vectors;
-
-    std::vector<int> result_idx = fusion_relative(args);
-    for (auto i = 0; i < result_idx.size(); i++) {
-        result.SetValue(i, args.data[result_idx[i]].GetValue(i));
+    for (auto i = 0; i < args.size(); i++) {
+        auto max = 0.0;
+        for (auto j = 0; j < args.ColumnCount(); j++) {
+            auto value = args.data[j].GetValue(i).GetValue<double>();
+            if (value > max) {
+                max = value;
+            }
+        }
+        result.SetValue(i, max);
     }
 }
 

--- a/src/core/functions/scalar/fusion_relative.cpp
+++ b/src/core/functions/scalar/fusion_relative.cpp
@@ -1,0 +1,78 @@
+#include <flockmtl/common.hpp>
+#include <flockmtl/core/functions/scalar.hpp>
+#include <flockmtl/core/model_manager/model_manager.hpp>
+#include <flockmtl/core/parser/llm_response.hpp>
+#include <flockmtl/core/parser/scalar.hpp>
+#include <flockmtl_extension.hpp>
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace flockmtl {
+namespace core {
+
+std::vector<double> normalize(const std::vector<double> &scores) {
+
+    double min_val = *std::min_element(scores.begin(), scores.end());
+    double max_val = *std::max_element(scores.begin(), scores.end());
+
+    std::vector<double> normalized;
+    if (max_val == min_val) {
+        normalized.resize(scores.size(), 0.0);
+    } else {
+        for (double score : scores) {
+            normalized.push_back((score - min_val) / (max_val - min_val));
+        }
+    }
+
+    return normalized;
+}
+
+std::vector<int> fusion_relative(DataChunk &args) {
+    size_t column_size = args.ColumnCount();
+    size_t tuple_size = args.size();
+
+    std::vector<std::vector<double>> normalized_columns;
+    for (size_t i = 0; i < column_size; i++) {
+        std::vector<double> scores;
+        for (size_t j = 0; j < tuple_size; j++) {
+            scores.push_back(args.data[i].GetValue(j).GetValue<double>());
+        }
+        std::vector<double> normalized_scores = normalize(scores);
+        normalized_columns.push_back(normalized_scores);
+    }
+
+    std::vector<int> result_idx;
+    for (size_t i = 0; i < tuple_size; i++) {
+        double max_score = 0.0;
+        int max_idx = 0;
+        for (size_t j = 0; j < column_size; j++) {
+            if (normalized_columns[j][i] > max_score) {
+                max_score = normalized_columns[j][i];
+                max_idx = j;
+            }
+        }
+        result_idx.push_back(max_idx);
+    }
+
+    return result_idx;
+}
+
+static void FusionRelativeScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+    CoreScalarParsers::FusionRelativeScalarParser(args);
+
+    std::vector<std::vector<double>> score_vectors;
+
+    std::vector<int> result_idx = fusion_relative(args);
+    for (auto i = 0; i < result_idx.size(); i++) {
+        result.SetValue(i, args.data[result_idx[i]].GetValue(i));
+    }
+}
+
+void CoreScalarFunctions::RegisterFusionRelativeScalarFunction(DatabaseInstance &db) {
+    ExtensionUtil::RegisterFunction(db, ScalarFunction("fusion_relative", {}, LogicalType::DOUBLE,
+                                                       FusionRelativeScalarFunction, nullptr, nullptr, nullptr, nullptr,
+                                                       LogicalType::ANY));
+}
+
+} // namespace core
+} // namespace flockmtl

--- a/src/core/parser/scalar/CMakeLists.txt
+++ b/src/core/parser/scalar/CMakeLists.txt
@@ -4,4 +4,5 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_complete.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_embedding.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llm_filter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fusion_relative.cpp
     PARENT_SCOPE)

--- a/src/core/parser/scalar/fusion_relative.cpp
+++ b/src/core/parser/scalar/fusion_relative.cpp
@@ -1,0 +1,18 @@
+#include <flockmtl/common.hpp>
+#include <flockmtl/core/functions/scalar.hpp>
+#include <flockmtl/core/parser/scalar.hpp>
+#include <flockmtl_extension.hpp>
+
+namespace flockmtl {
+namespace core {
+
+void CoreScalarParsers::FusionRelativeScalarParser(DataChunk &args) {
+    for (int i = 0; i < args.ColumnCount(); i++) {
+        if (args.data[i].GetType() != LogicalType::DOUBLE) {
+            throw std::runtime_error("fusion_relative: argument must be a double");
+        }
+    }
+}
+
+} // namespace core
+} // namespace flockmtl

--- a/src/include/flockmtl/core/functions/scalar.hpp
+++ b/src/include/flockmtl/core/functions/scalar.hpp
@@ -11,6 +11,7 @@ struct CoreScalarFunctions {
         RegisterLlmCompleteScalarFunction(db);
         RegisterLlmEmbeddingScalarFunction(db);
         RegisterLlmFilterScalarFunction(db);
+        RegisterFusionRelativeScalarFunction(db);
     }
 
 private:
@@ -18,6 +19,7 @@ private:
     static void RegisterLlmCompleteScalarFunction(DatabaseInstance &db);
     static void RegisterLlmEmbeddingScalarFunction(DatabaseInstance &db);
     static void RegisterLlmFilterScalarFunction(DatabaseInstance &db);
+    static void RegisterFusionRelativeScalarFunction(DatabaseInstance &db);
 };
 
 } // namespace core

--- a/src/include/flockmtl/core/parser/scalar.hpp
+++ b/src/include/flockmtl/core/parser/scalar.hpp
@@ -13,6 +13,7 @@ struct CoreScalarParsers {
     static void LlmCompleteScalarParser(DataChunk &args);
     static void LlmFilterScalarParser(DataChunk &args);
     static void LlmEmbeddingScalarParser(DataChunk &args);
+    static void FusionRelativeScalarParser(DataChunk &args);
 };
 
 } // namespace core


### PR DESCRIPTION
This PR introduces the `fusion_relative` scalar function, which takes scores from multiple columns, normalizes each column's values, and computes the maximum score for each tuple. This functionality is useful for combining scores from different scoring mechanisms, such as BM25 and vector search, into a unified ranking.  

### Key Features:  
- **Normalization:** Normalizes the scores of each input column.  
- **Tuple Aggregation:** Computes the maximum score for each tuple across the normalized column scores.  
- **Usage Example:**  
  ```sql  
  SELECT fusion_relative(bm25_score, vector_search_score) AS score  
  FROM index_table;  
  ```  