### PR TITLE
Add Support for Configuring Secrets for Multiple Model Providers

### DIFF
--- a/src/core/functions/batch_response_builder.cpp
+++ b/src/core/functions/batch_response_builder.cpp
@@ -89,7 +89,7 @@ PromptDetails CreatePromptDetails(Connection &con, const nlohmann::json prompt_d
 }
 
 nlohmann::json Complete(const nlohmann::json &tuples, const std::string &user_prompt, ScalarFunctionType function_type,
-                        const ModelDetails &model_details) {
+                        ModelDetails &model_details) {
     nlohmann::json data;
     auto tuples_markdown = ConstructMarkdownArrayTuples(tuples);
     auto prompt = ScalarPromptTemplate::GetPrompt(user_prompt, tuples_markdown, function_type);
@@ -98,7 +98,7 @@ nlohmann::json Complete(const nlohmann::json &tuples, const std::string &user_pr
 };
 
 nlohmann::json BatchAndComplete(std::vector<nlohmann::json> &tuples, Connection &con, std::string user_prompt,
-                                ScalarFunctionType function_type, const ModelDetails &model_details) {
+                                ScalarFunctionType function_type, ModelDetails &model_details) {
     auto llm_template = ScalarPromptTemplate::GetPromptTemplate(function_type);
 
     int num_tokens_meta_and_user_pormpt = 0;

--- a/src/core/parser/query/secret_parser.cpp
+++ b/src/core/parser/query/secret_parser.cpp
@@ -44,7 +44,8 @@ void SecretParser::ParseCreateSecret(Tokenizer &tokenizer, std::unique_ptr<Query
     if (token.type != TokenType::KEYWORD || (value != "OPENAI" && value != "AZURE")) {
         throw std::runtime_error("Expected 'OPENAI' keyword after 'SECRET'.");
     }
-    auto provider = value;
+
+    auto provider = StringUtil::Lower(value);
 
     token = tokenizer.NextToken();
     if (token.type != TokenType::SYMBOL || token.value != "=") {
@@ -80,7 +81,8 @@ void SecretParser::ParseDeleteSecret(Tokenizer &tokenizer, std::unique_ptr<Query
     if (token.type != TokenType::KEYWORD || (value != "OPENAI" && value != "AZURE")) {
         throw std::runtime_error("Expected 'OPENAI' keyword after 'SECRET'.");
     }
-    auto provider = value;
+
+    auto provider = StringUtil::Lower(value);
 
     token = tokenizer.NextToken();
     if (token.type == TokenType::SYMBOL || token.value == ";") {
@@ -103,7 +105,8 @@ void SecretParser::ParseUpdateSecret(Tokenizer &tokenizer, std::unique_ptr<Query
     if (token.type != TokenType::KEYWORD || (value != "OPENAI" && value != "AZURE")) {
         throw std::runtime_error("Expected 'OPENAI' keyword after 'SECRET'.");
     }
-    auto provider = value;
+
+    auto provider = StringUtil::Lower(value);
 
     token = tokenizer.NextToken();
     if (token.type != TokenType::SYMBOL || token.value != "=") {
@@ -143,7 +146,7 @@ void SecretParser::ParseGetSecret(Tokenizer &tokenizer, std::unique_ptr<QuerySta
         if (token.type != TokenType::KEYWORD || (value != "OPENAI" && value != "AZURE")) {
             throw std::runtime_error("Expected 'OPENAI' or 'AZURE' keyword after 'SECRET'.");
         }
-        auto provider = value;
+        auto provider = StringUtil::Lower(value);
 
         token = tokenizer.NextToken();
         if (token.type == TokenType::SYMBOL || token.value == ";") {

--- a/src/include/flockmtl/core/functions/batch_response_builder.hpp
+++ b/src/include/flockmtl/core/functions/batch_response_builder.hpp
@@ -24,10 +24,10 @@ std::string ConstructMarkdownArrayTuples(const nlohmann::json &tuples);
 PromptDetails CreatePromptDetails(Connection &con, const nlohmann::json prompt_details_json);
 
 nlohmann::json Complete(const nlohmann::json &tuples, const std::string &user_prompt, ScalarFunctionType function_type,
-                        const ModelDetails &model_details);
+                        ModelDetails &model_details);
 
 nlohmann::json BatchAndComplete(std::vector<nlohmann::json> &tuples, Connection &con, std::string user_prompt_name,
-                                ScalarFunctionType function_type, const ModelDetails &model_details);
+                                ScalarFunctionType function_type, ModelDetails &model_details);
 
 } // namespace core
 } // namespace flockmtl

--- a/src/include/flockmtl/core/model_manager/model_manager.hpp
+++ b/src/include/flockmtl/core/model_manager/model_manager.hpp
@@ -6,6 +6,7 @@
 #include <tuple>
 #include <vector>
 #include <string>
+#include <flockmtl/core/model_manager/supported_providers.hpp>
 
 namespace flockmtl {
 namespace core {
@@ -24,20 +25,23 @@ struct ModelDetails {
     int context_window;
     int max_output_tokens;
     float temperature;
+    std::string secret;
 };
 
 struct ModelManager {
 public:
     static ModelDetails CreateModelDetails(Connection &con, const nlohmann::json &model_json);
 
-    static nlohmann::json CallComplete(const std::string &prompt, const ModelDetails &model_details,
+    static nlohmann::json CallComplete(const std::string &prompt, ModelDetails &model_details,
                                        const bool json_response = true);
 
-    static nlohmann::json CallEmbedding(const std::vector<string> &inputs, const ModelDetails &model_details);
+    static nlohmann::json CallEmbedding(const std::vector<string> &inputs, ModelDetails &model_details);
 
 private:
     static std::tuple<std::string, int32_t, int32_t> GetQueriedModel(Connection &con, const std::string &model_name,
                                                                      const std::string &provider_name);
+
+    static std::string GetProviderSecret(const SupportedProviders &provider);
 
     static nlohmann::json OpenAICallComplete(const std::string &prompt, const ModelDetails &model_details,
                                              const bool json_response);
@@ -59,11 +63,11 @@ private:
 
     static nlohmann::json AwsBedrockCallEmbedding(const std::vector<string> &inputs, const ModelDetails &model_details);
 
-    static std::pair<bool, nlohmann::json>
-    CallCompleteProvider(const std::string &prompt, const ModelDetails &model_details, const bool json_response);
+    static std::pair<bool, nlohmann::json> CallCompleteProvider(const std::string &prompt, ModelDetails &model_details,
+                                                                const bool json_response);
 
     static std::pair<bool, nlohmann::json> CallEmbeddingProvider(const std::vector<string> &inputs,
-                                                                 const ModelDetails &model_details);
+                                                                 ModelDetails &model_details);
 };
 
 } // namespace core

--- a/src/include/flockmtl/core/model_manager/supported_providers.hpp
+++ b/src/include/flockmtl/core/model_manager/supported_providers.hpp
@@ -30,3 +30,18 @@ inline SupportedProviders GetProviderType(std::string provider) {
 
     return FLOCKMTL_UNSUPPORTED_PROVIDER;
 }
+
+inline std::string GetProviderName(SupportedProviders provider) {
+    switch (provider) {
+    case FLOCKMTL_OPENAI:
+        return OPENAI;
+    case FLOCKMTL_AZURE:
+        return AZURE;
+    case FLOCKMTL_OLLAMA:
+        return OLLAMA;
+    case FLOCKMTL_AWS_BEDROCK:
+        return BEDROCK;
+    default:
+        return "";
+    }
+}


### PR DESCRIPTION
This pull request add the ability to access secrets required for completing operations and embedding functionalities with Azure and OpenAI services.

If a secret is not found in the internal table, the system automatically falls back to checking the environment variables.