### PR TITLE
Fix Windows Build by Enabling C++17

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,8 +4,6 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,6 +4,8 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 # Set extension name here
 set(TARGET_NAME flockmtl)
 


### PR DESCRIPTION
This PR resolves all Windows build errors by enabling the /std:c++17 compiler flag. The following issues have been addressed:

- Structured Bindings: Enabled structured bindings support required for iterating over objects like model_json.items().
- Ambiguity in std::stoi and std::stof: Resolved by enforcing C++17 standard compliance.
- std::invalid_argument Constructor Issue: Fixed as part of enabling C++17, ensuring proper exception handling.